### PR TITLE
allow terms that are also the names of JavaScript builtins

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class Glossary {
   add (term, description) {
     assert(term && term.length, 'term is required')
     assert(description && description.length, 'description is required')
-    assert(!(term in this._entries), `term ${term} has already been added`)
+    assert(!(Object.keys(this.entries).includes(term)), `term ${term} has already been added`)
     this._entries[term] = description
   }
 

--- a/test.js
+++ b/test.js
@@ -56,6 +56,12 @@ describe('glossary.add()', () => {
       glossary.add('IPC', 'inter-process communication')
     }).toThrow('term IPC has already been added')
   })
+
+  test('properly handles JS builtins like `constructor`', () => {
+    glossary.add('constructor', 'a thing')
+    glossary.add('toString', 'a thing')
+    glossary.add('hasOwnProperty', 'a thing')
+  })
 })
 
 describe('glossary.webpage', () => {


### PR DESCRIPTION
Fixes this:

```
Array
ArrayBuffer
Atomics
Boolean
constructor
(node:21975) UnhandledPromiseRejectionWarning: AssertionError [ERR_ASSERTION]: term constructor has already been added
```